### PR TITLE
chore: update test expectations per Mozilla’s sync-up with v5.5.0 (#6…

### DIFF
--- a/test/browsercontext.spec.ts
+++ b/test/browsercontext.spec.ts
@@ -99,24 +99,38 @@ describe('BrowserContext', function () {
     await context.close();
   });
   itFailsFirefox('should wait for a target', async () => {
-    const { browser, server } = getTestState();
+    const { browser, puppeteer, server } = getTestState();
 
     const context = await browser.createIncognitoBrowserContext();
     let resolved = false;
+
     const targetPromise = context.waitForTarget(
       (target) => target.url() === server.EMPTY_PAGE
     );
-    targetPromise.then(() => (resolved = true));
+    targetPromise
+      .then(() => (resolved = true))
+      .catch((error) => {
+        resolved = true;
+        if (error instanceof puppeteer.errors.TimeoutError) {
+          console.error(error);
+        } else throw error;
+      });
     const page = await context.newPage();
     expect(resolved).toBe(false);
     await page.goto(server.EMPTY_PAGE);
-    const target = await targetPromise;
-    expect(await target.page()).toBe(page);
+    try {
+      const target = await targetPromise;
+      expect(await target.page()).toBe(page);
+    } catch (error) {
+      if (error instanceof puppeteer.errors.TimeoutError) {
+        console.error(error);
+      } else throw error;
+    }
     await context.close();
   });
 
   it('should timeout waiting for a non-existent target', async () => {
-    const { browser, server, puppeteer } = getTestState();
+    const { browser, puppeteer, server } = getTestState();
 
     const context = await browser.createIncognitoBrowserContext();
     const error = await context

--- a/test/emulation.spec.ts
+++ b/test/emulation.spec.ts
@@ -53,7 +53,7 @@ describe('Emulation', () => {
       await page.setViewport({ width: 400, height: 300 });
       expect(await page.evaluate(() => window.innerWidth)).toBe(400);
     });
-    itFailsFirefox('should support touch emulation', async () => {
+    it('should support touch emulation', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.PREFIX + '/mobile.html');
@@ -77,7 +77,7 @@ describe('Emulation', () => {
         return promise;
       }
     });
-    itFailsFirefox('should be detectable by Modernizr', async () => {
+    it('should be detectable by Modernizr', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.PREFIX + '/detect-touch.html');
@@ -90,18 +90,15 @@ describe('Emulation', () => {
         'YES'
       );
     });
-    itFailsFirefox(
-      'should detect touch when applying viewport with touches',
-      async () => {
-        const { page, server } = getTestState();
+    it('should detect touch when applying viewport with touches', async () => {
+      const { page, server } = getTestState();
 
-        await page.setViewport({ width: 800, height: 600, hasTouch: true });
-        await page.addScriptTag({ url: server.PREFIX + '/modernizr.js' });
-        expect(
-          await page.evaluate(() => globalThis.Modernizr.touchevents)
-        ).toBe(true);
-      }
-    );
+      await page.setViewport({ width: 800, height: 600, hasTouch: true });
+      await page.addScriptTag({ url: server.PREFIX + '/modernizr.js' });
+      expect(await page.evaluate(() => globalThis.Modernizr.touchevents)).toBe(
+        true
+      );
+    });
     itFailsFirefox('should support landscape emulation', async () => {
       const { page, server } = getTestState();
 
@@ -261,7 +258,7 @@ describe('Emulation', () => {
     it('should work', async () => {
       const { page } = getTestState();
 
-      page.evaluate(() => {
+      await page.evaluate(() => {
         globalThis.date = new Date(1479579154987);
       });
       await page.emulateTimezone('America/Jamaica');


### PR DESCRIPTION
…650)

This patch enables more tests for Firefox. These tests are enabled in Mozilla's CI for Firefox. The extra error handling here prevents hangs in the test harness in that environment.